### PR TITLE
Fix the link issues with skill and spell instance windows

### DIFF
--- a/campaign/record_ability.xml
+++ b/campaign/record_ability.xml
@@ -44,17 +44,7 @@
 
 	<windowclass name="ability_header">
 		<margins control="0,0,0,7" />
-		<script>
-			function onInit()
-				update();
-			end
-			function update()
-				local nodeRecord = getDatabaseNode();
-
-				local bReadOnly = WindowManager.getReadOnlyState(nodeRecord);
-				name.setReadOnly(bReadOnly);
-			end
-		</script>
+		<script file="campaign/scripts/charsheet/ability_header.lua" />
 		<sheetdata>
 			<link_record_header name="link">
 				<class>ability</class>

--- a/campaign/record_char_skills.xml
+++ b/campaign/record_char_skills.xml
@@ -443,8 +443,6 @@
 			</label_column>
 			<string_columnh name="prereqs" />
 
-			<ft_columnh name="text" />
-
 			<label_column name="page_label">
 				<static textres="ability_page_label" />
 			</label_column>
@@ -459,6 +457,8 @@
 				<static textres="ability_points_adjustment_label" />
 			</label_column>
 			<number_columnh name="points_adj" />
+
+			<ft_columnh name="text" />
 		</sheetdata>
 	</windowclass>
 </root>

--- a/campaign/record_char_skills.xml
+++ b/campaign/record_char_skills.xml
@@ -390,7 +390,7 @@
 		<script file="campaign/scripts/charsheet/char_skill_flyout.lua" />
 		<sheetdata>
 			<sub_record_header name="header">
-				<class>ability_header</class>
+				<class>skill_instance_header</class>
 			</sub_record_header>
 
 			<frame_record_content name="contentframe" />
@@ -459,6 +459,26 @@
 			<number_columnh name="points_adj" />
 
 			<ft_columnh name="text" />
+		</sheetdata>
+	</windowclass>
+
+	<windowclass name="skill_instance_header">
+		<margins control="0,0,0,7" />
+		<script  file="campaign/scripts/charsheet/ability_header.lua" />
+		<sheetdata>
+			<linkcontrol name="link">
+				<bounds>5,5,20,20</bounds>
+				<class>char_skill_flyout</class>
+				<readonly />
+			</linkcontrol>
+
+			<anchor_record_header_right name="rightanchor" />
+			<icon_record_locked />
+			<button_record_locked />
+
+			<string_record_name name="name">
+				<empty textres="library_recordtype_empty_item" />
+			</string_record_name>
 		</sheetdata>
 	</windowclass>
 </root>

--- a/campaign/record_char_spells.xml
+++ b/campaign/record_char_spells.xml
@@ -413,7 +413,7 @@
 		<script file="campaign/scripts/charsheet/char_spell_flyout.lua" />
 		<sheetdata>
 			<sub_record_header name="header">
-				<class>ability_header</class>
+				<class>spell_instance_header</class>
 			</sub_record_header>
 
 			<frame_record_content name="contentframe" />
@@ -520,6 +520,26 @@
 			<number_columnh name="points_adj" />
 
 			<ft_columnh name="text" />
+		</sheetdata>
+	</windowclass>
+
+	<windowclass name="spell_instance_header">
+		<margins control="0,0,0,7" />
+		<script file="campaign/scripts/charsheet/ability_header.lua" />
+		<sheetdata>
+			<linkcontrol name="link">
+				<bounds>5,5,20,20</bounds>
+				<class>char_spell_flyout</class>
+				<readonly />
+			</linkcontrol>
+
+			<anchor_record_header_right name="rightanchor" />
+			<icon_record_locked />
+			<button_record_locked />
+
+			<string_record_name name="name">
+				<empty textres="library_recordtype_empty_item" />
+			</string_record_name>
 		</sheetdata>
 	</windowclass>
 </root>

--- a/campaign/record_char_spells.xml
+++ b/campaign/record_char_spells.xml
@@ -479,8 +479,6 @@
 			</label_column>
 			<string_columnh name="resist" />
 
-			<ft_columnh name="text" />
-
 			<label_column name="duration_label">
 				<static textres="ability_spellduration_label" />
 			</label_column>
@@ -520,6 +518,8 @@
 				<static textres="ability_points_adjustment_label" />
 			</label_column>
 			<number_columnh name="points_adj" />
+
+			<ft_columnh name="text" />
 		</sheetdata>
 	</windowclass>
 </root>

--- a/campaign/scripts/charsheet/ability_header.lua
+++ b/campaign/scripts/charsheet/ability_header.lua
@@ -1,0 +1,14 @@
+-- 
+-- Please see the license.html file included with this distribution for 
+-- attribution and copyright information.
+--
+
+function onInit()
+    update();
+end
+
+function update()
+    local nodeRecord = getDatabaseNode();
+    local bReadOnly = WindowManager.getReadOnlyState(nodeRecord);
+    name.setReadOnly(bReadOnly);
+end

--- a/campaign/scripts/charsheet/char_skill_flyout.lua
+++ b/campaign/scripts/charsheet/char_skill_flyout.lua
@@ -29,7 +29,7 @@ end
 function onNameUpdated()
 	local nodeRecord = getDatabaseNode();
 	
-	local sTooltip = DB.getValue(charSkillNode, "name", "");
+	local sTooltip = DB.getValue(nodeRecord, "name", "");
 	if sTooltip == "" then
 		sTooltip = Interface.getString("library_recordtype_empty_item")
 	end

--- a/campaign/scripts/charsheet/char_spell_flyout.lua
+++ b/campaign/scripts/charsheet/char_spell_flyout.lua
@@ -29,7 +29,7 @@ end
 function onNameUpdated()
 	local nodeRecord = getDatabaseNode();
 	
-	local sTooltip = DB.getValue(charSkillNode, "name", "");
+	local sTooltip = DB.getValue(nodeRecord, "name", "");
 	if sTooltip == "" then
 		sTooltip = Interface.getString("library_recordtype_empty_item")
 	end


### PR DESCRIPTION
The windows I added had an issue with the links in the title bar of the window. The first one was that they always said "New Item" because I overlooked a renamed variable. The second thing is that the link itself was still trying to open a library ability window. I changed this so that it links back to the charsheet's instance data.

The end result of the change is that folks can now click on the links from their charsheet have it open with the skill/spell instance information, instead of a mistake.

Also I moved the descriptive text in spell and skill instance windows to the bottom as requested.