### PR TITLE
Fixed adding spells to character

### DIFF
--- a/scripts/manager_actor2.lua
+++ b/scripts/manager_actor2.lua
@@ -345,22 +345,21 @@ function addAbility(nodeChar, nodeAbility)
 		if not skillData then
 			return false;
 		end
-
 		local nodeSpell = DB.createChild(nodeSpellsList);
 		DB.setValue(nodeSpell, "name", "string", DB.getValue(nodeAbility,"name",""));
-		DB.setValue(nodeSpell, "class", "string", DB.getValue(nodeAbility,"spellclass",""));
-		DB.setValue(nodeSpell, "time", "string", DB.getValue(nodeAbility,"spelltimetocast",""));
-		DB.setValue(nodeSpell, "duration", "string", DB.getValue(nodeAbility,"spellduration",""));
-		DB.setValue(nodeSpell, "costmaintain", "string", DB.getValue(nodeAbility,"spellcost",""));
-		DB.setValue(nodeSpell, "resist", "string", DB.getValue(nodeAbility,"spellresist",""));
-		DB.setValue(nodeSpell, "college", "string", DB.getValue(nodeAbility,"spellcollege",""));
 		DB.setValue(nodeSpell, "page", "string", DB.getValue(nodeAbility,"page",""));
+		DB.setValue(nodeSpell, "class", "string", DB.getValue(nodeAbility,"spellclass",""));
+		DB.setValue(nodeSpell, "college", "string", DB.getValue(nodeAbility,"spellcollege",""));
+		DB.setValue(nodeSpell, "spellcost", "string", DB.getValue(nodeAbility,"spellcost",""));
+		DB.setValue(nodeSpell, "duration", "string", DB.getValue(nodeAbility,"spellduration",""));
+		DB.setValue(nodeSpell, "prereqs", "string", DB.getValue(nodeAbility,"spellprerequisite",""));
+		DB.setValue(nodeSpell, "resist", "string", DB.getValue(nodeAbility,"spellresist",""));
+		DB.setValue(nodeSpell, "time", "string", DB.getValue(nodeAbility,"spelltimetocast",""));
 		DB.setValue(nodeSpell, "text", "formattedtext", DB.getValue(nodeAbility,"text",""));
+		DB.setValue(nodeSpell, "type", "string", skillData.abbreviatedSkillType);
 		DB.setValue(nodeSpell, "level_adj", "number", 0);
 		DB.setValue(nodeSpell, "points_adj", "number", 0);
 		DB.setValue(nodeSpell, "points", "number", 1);
-		DB.setValue(nodeSpell, "type", "string", skillData.abbreviatedSkillType);
-
 		return true;
 	end
 


### PR DESCRIPTION
DB now stores spell properties in the charsheet in the same order as in the ability list.
Spell prerequisites and costs were not transferring over. This has been fixed.