### PR TITLE
Fix skill basis not being entered and always preserve level adjustments.

### DIFF
--- a/scripts/manager_actor2.lua
+++ b/scripts/manager_actor2.lua
@@ -289,6 +289,7 @@ function addAbility(nodeChar, nodeAbility)
 		end
 
 		local nodeSkill = DB.createChild(nodeSkillsList);
+		DB.setValue(nodeSkill, "basis", "string", abilityInfo.basis);  
 		DB.setValue(nodeSkill, "name", "string", abilityName);
 		DB.setValue(nodeSkill, "text", "formattedtext", DB.getValue(nodeAbility,"text",""));
 		DB.setValue(nodeSkill, "defaults", "string", DB.getValue(nodeAbility,"skilldefault",""));

--- a/scripts/manager_version2.lua
+++ b/scripts/manager_version2.lua
@@ -661,9 +661,12 @@ function migrateChar9(nodeChar)
       local defaultsLine = DB.getValue(nodeOld, "defaults", "");
       local level_adjust = DB.getValue(nodeOld, "level_adj", 0);
       local abilityInfo = ActorAbilityManager.calculateAbilityInfo(nodeChar, abilityType, totalCP, abilityName, defaultsLine, level_adjust);
-      if abilityInfo and abilityInfo.level ~= desiredLevel then
-        print("Adjusting level for '" .. abilityInfo.name .. "' skill on '" .. characterName .. "'. Old level is '" .. desiredLevel .. "' but calculated level was '" .. abilityInfo.level .. "'.");
-        DB.setValue(nodeOld, "level_adj", "number", desiredLevel - abilityInfo.level);
+      if abilityInfo then
+        DB.setValue(nodeOld, "basis", "string", abilityInfo.basis);
+        if abilityInfo.level ~= desiredLevel then
+          print("Adjusting level for '" .. abilityInfo.name .. "' skill on '" .. characterName .. "'. Old level is '" .. desiredLevel .. "' but calculated level was '" .. abilityInfo.level .. "'.");
+          DB.setValue(nodeOld, "level_adj", "number", desiredLevel - abilityInfo.level);
+        end
       end
     end
   end

--- a/scripts/manager_version2.lua
+++ b/scripts/manager_version2.lua
@@ -651,17 +651,19 @@ end
 
 function migrateChar9(nodeChar)
   -- adjust existing skills and spells to take into accunt the existance of the new bonus levels feature.
+  local characterName = DB.getValue(nodeChar, "name", "");
   if DB.getChild(nodeChar, "abilities.skilllist") then
     for _,nodeOld in pairs(DB.getChildren(nodeChar, "abilities.skilllist")) do
       local totalCP = DB.getValue(nodeOld, "points", 0);
       local abilityName = DB.getValue(nodeOld, "name", "");
       local abilityType = DB.getValue(nodeOld, "type", "");
       local desiredLevel = DB.getValue(nodeOld, "level", 0);
-      local abilityInfo = ActorAbilityManager.calculateAbilityInfo(nodeChar, abilityType, totalCP, abilityName, "", 0);
-      if abilityInfo then
-        if abilityInfo.level ~= desiredLevel then
-          DB.setValue(nodeOld, "level_adj", "number", desiredLevel - abilityInfo.level);
-        end
+      local defaultsLine = DB.getValue(nodeOld, "defaults", "");
+      local level_adjust = DB.getValue(nodeOld, "level_adj", 0);
+      local abilityInfo = ActorAbilityManager.calculateAbilityInfo(nodeChar, abilityType, totalCP, abilityName, defaultsLine, level_adjust);
+      if abilityInfo and abilityInfo.level ~= desiredLevel then
+        print("Adjusting level for '" .. abilityInfo.name .. "' skill on '" .. characterName .. "'. Old level is '" .. desiredLevel .. "' but calculated level was '" .. abilityInfo.level .. "'.");
+        DB.setValue(nodeOld, "level_adj", "number", desiredLevel - abilityInfo.level);
       end
     end
   end
@@ -673,11 +675,11 @@ function migrateChar9(nodeChar)
       local abilityName = DB.getValue(nodeOld, "name", "");
       local abilityType = DB.getValue(nodeOld, "type", "");
       local desiredLevel = DB.getValue(nodeOld, "level", 0);
-      local abilityInfo = ActorAbilityManager.calculateAbilityInfo(nodeChar, abilityType, totalCP, abilityName, "", 0);
-      if abilityInfo then
-        if abilityInfo.level ~= desiredLevel then
-          DB.setValue(nodeOld, "level_adj", "number", desiredLevel - abilityInfo.level);
-        end
+      local level_adjust = DB.getValue(nodeOld, "level_adj", 0);
+      local abilityInfo = ActorAbilityManager.calculateAbilityInfo(nodeChar, abilityType, totalCP, abilityName, "", level_adjust);
+      if abilityInfo and abilityInfo.level ~= desiredLevel then
+        print("Adjusting level for '" .. abilityInfo.name .. "' spell on '" .. characterName .. "'. Old level is '" .. desiredLevel .. "' but calculated level was '" .. abilityInfo.level .. "'.");
+        DB.setValue(nodeOld, "level_adj", "number", desiredLevel - abilityInfo.level);
       end
     end
   end


### PR DESCRIPTION
Last commit had a bug with the skill basis... it wasn't being set. We were also not setting Technique levels if there was no default information. Now, the ability level adjustment will be used in all cases when the ability calculator can't figure out what the skill level should be.

I had considered making the techniques try to figure out the default skill based on its name (e.g. "Groin-Kick (Karate)"), but without assurances of the modifier information (e.g. Karate-3), this leads to the techniques coming out to an incorrect value. Leaving it alone allows the user to have a correct character import and then fix the skills as needed.